### PR TITLE
Fix for Autoscroll with Playhead Preference

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
                       cmake_preset: "mac-universal"
                       build_config: "Release"
                     - name: "Windows"
-                      os: "windows-2019"
+                      os: "windows-2022"
                       cmake_preset: "windows-native"
                       build_config: "Release"
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
 set(PROJECT_NAME "GPLyricsChords") 
-set (PROJECT_VERSION "1.3.1")
+set (PROJECT_VERSION "1.3.2")
 set (PROJECT_TITLE "GP Lyrics/Chords")
 set (PROJECT_DESCR "Lyrics and Chords Viewer and Editor")
 string(TIMESTAMP TODAY "%d/%m/%Y")

--- a/src/ExtensionWindow.cpp
+++ b/src/ExtensionWindow.cpp
@@ -2997,7 +2997,7 @@ void ExtensionWindow::setSongPanelToFloating(bool isFloating) {
 
 void ExtensionWindow::playheadChange(bool playing) {
     if (extension == nullptr) return;
-    if (playing) {
+    if (playing && autoscrollStartWithPlayhead) {
         MessageManager::getInstance()->callAsync([]() {
             chordProAutoScrollPlay(true);
         });

--- a/src/Version.h
+++ b/src/Version.h
@@ -4,7 +4,7 @@
 const std::string PROJECT_NAME = "GPLyricsChords";
 const std::string PROJECT_TITLE = "GP Lyrics/Chords";
 const std::string PROJECT_DESCRIPTION = "Lyrics and Chords Viewer and Editor";
-const std::string PROJECT_VERSION = "1.3.1";
-const std::string PROJECT_BUILD_DATE = "18/05/2025";
+const std::string PROJECT_VERSION = "1.3.2";
+const std::string PROJECT_BUILD_DATE = "23/11/2025";
 
 #endif // VERSION_H


### PR DESCRIPTION
Preference setting wasn't changing the behaviour of whether or not the ChordPro autoscroll was starting with the GP global playhead.